### PR TITLE
Feature/40835 (Material UI - Styling, Dialog, and Form Validation)

### DIFF
--- a/training/package.json
+++ b/training/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.2",
+    "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.2",
     "@testing-library/user-event": "^12.5.0",

--- a/training/package.json
+++ b/training/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@material-ui/core": "^4.11.2",
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.2",
     "@testing-library/user-event": "^12.5.0",

--- a/training/src/App.jsx
+++ b/training/src/App.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { ChildrenDemo } from './pages';
+import { Trainee } from './pages';
 
 function App() {
   return (
-    <ChildrenDemo />
+    <Trainee />
   );
 }
 export default App;

--- a/training/src/App.jsx
+++ b/training/src/App.jsx
@@ -1,9 +1,9 @@
-import { InputDemo } from './pages';
+import React from 'react';
+import { ChildrenDemo } from './pages';
 
 function App() {
   return (
-    // eslint-disable-next-line react/react-in-jsx-scope
-    <InputDemo />
+    <ChildrenDemo />
   );
 }
 export default App;

--- a/training/src/components/Math/Math.jsx
+++ b/training/src/components/Math/Math.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Text = (props) => {
+  const {
+    first, second, operator, children,
+  } = props;
+  let { result } = props;
+  switch (operator) {
+  case '+': result = first + second;
+    break;
+  case '-': result = first - second;
+    break;
+  case '/': result = first / second;
+    break;
+  case '*': result = first * second;
+    break;
+  default: return (`${operator} of ${first} and ${second} is an Invalid Operator`);
+  } if (children) {
+    return children(first, second, result);
+  }
+  return (
+    <>
+      <p>
+        {' '}
+        {first}
+        {' '}
+        {operator}
+        {' '}
+        {second}
+        {' '}
+        =
+        {' '}
+        {result}
+        {' '}
+      </p>
+    </>
+  );
+};
+Text.propTypes = {
+  first: PropTypes.number.isRequired,
+  second: PropTypes.number.isRequired,
+  operator: PropTypes.string.isRequired,
+  result: PropTypes.number.isRequired,
+  children: PropTypes.func,
+};
+Text.defaultProps = {
+  children: undefined,
+};
+export default Text;

--- a/training/src/components/Math/index.js
+++ b/training/src/components/Math/index.js
@@ -1,0 +1,1 @@
+export { default as Math } from './Math';

--- a/training/src/components/index.js
+++ b/training/src/components/index.js
@@ -3,3 +3,4 @@ export { Slider } from './Slider';
 export { SelectField } from './SelectField';
 export { RadioField } from './RadioField';
 export { ButtonField } from './Button';
+export { Math } from './Math';

--- a/training/src/pages/ChildrenDemo/ChildrenDemo.jsx
+++ b/training/src/pages/ChildrenDemo/ChildrenDemo.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { ThemeProvider } from '@material-ui/core';
+import Text from '../../components/Math/Math';
+import Theme from '../../theme';
+
+export default class CalculatorDemo extends React.Component {
+  Result() {
+    let { result } = this.state;
+    result = '';
+    this.setState({ result });
+  }
+
+  render() {
+    return (
+      <>
+        <ThemeProvider theme={Theme}>
+          <Text first={7} second={4} operator="+" />
+          <Text first={7} second={3} operator="-" />
+          <Text first={7} second={20} operator="*" />
+          <Text first={7} second={0} operator="/" />
+          <Text first={7} second={4} operator="+">
+            {
+              (first, second, result) => (
+                <p>
+                  Sum of
+                  {' '}
+                  {first}
+                  {' '}
+                  and
+                  {' '}
+                  {second}
+                  {' '}
+                  is equal to
+                  {' '}
+                  {result}
+                  {' '}
+                </p>
+              )
+            }
+          </Text>
+          <Text first={3} second={4} operator="+">
+            {
+              (first, second, result) => (
+                <p>
+                  When We add
+                  {' '}
+                  {first}
+                  {' '}
+                  with
+                  {' '}
+                  {second}
+                  {' '}
+                  than we will get
+                  {' '}
+                  {result}
+                  {' '}
+                  as result
+                </p>
+              )
+            }
+          </Text>
+        </ThemeProvider>
+      </>
+    );
+  }
+}

--- a/training/src/pages/ChildrenDemo/index.js
+++ b/training/src/pages/ChildrenDemo/index.js
@@ -1,0 +1,1 @@
+export { default as ChildrenDemo } from './ChildrenDemo';

--- a/training/src/pages/Trainee/Trainee.jsx
+++ b/training/src/pages/Trainee/Trainee.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Button } from '@material-ui/core';
+import { AddDialog } from './components';
+
+class Trainee extends React.Component{
+         constructor(props) {
+        super(props);
+        this.state={
+            open: false,
+        };
+         }
+         handleClickOpen = () => {
+             this.setState({open: true});
+          };
+        
+         handleClose = () => {
+             const { open }= this.state;
+            this.setState({open: false})
+            return open;
+          };
+
+          handleSubmit = (data) => {
+            this.setState({
+              open: false,
+            }, () => {
+              console.log(data);
+            });
+          }
+         render(){
+             const { open } = this.state;
+             return(
+                 <>
+                 <Button
+                 variant="outlined" 
+                 color="primary"
+                 onClick= {this.handleClickOpen} >
+                <b>ADD TRAINEE</b>
+                </Button>
+                <AddDialog 
+                open={open}
+                onClose= {this.handleClose}
+                onSubmit= {()=> this.handleSubmit}
+                >
+                </AddDialog>
+                </>
+             )
+         }
+
+}
+export default Trainee;

--- a/training/src/pages/Trainee/components/AddDialog/AddDialog.jsx
+++ b/training/src/pages/Trainee/components/AddDialog/AddDialog.jsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button, Dialog, DialogTitle, DialogContent, DialogContentText,
+} from '@material-ui/core';
+import { Email, VisibilityOff, Person } from '@material-ui/icons';
+import { withStyles } from '@material-ui/core/styles';
+import schema from './DialogSchema';
+import Handler from './Handler';
+
+const passwordStyle = () => ({
+  passfield: {
+    display: 'flex',
+    flexdirection: 'row',
+  },
+  pass: {
+    flex: 1,
+  },
+});
+
+const constant = {
+  Name: Person,
+  Email: Email,
+  Password: VisibilityOff,
+  'Confirm Password': VisibilityOff,
+};
+
+class AddDialog extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      Name: '',
+      Email: '',
+      Password: '',
+      ConfirmPassword: '',
+      touched: {
+        name: false,
+        email: false,
+        password: false,
+        confirmPassword: false,
+      },
+    };
+  }
+
+  handleChange = (key) => ({ target: { value } }) => {
+    this.setState({ [key]: value });
+  };
+
+    hasErrors = () => {
+      try {
+        schema.validateSync(this.state);
+      } catch (err) {
+        return true;
+      }
+      return false;
+    }
+
+    getError = (field) => {
+      const { touched } = this.state;
+      if (touched[field] && this.hasErrors()) {
+        try {
+          schema.validateSyncAt(field, this.state);
+          return '';
+        } catch (err) {
+          return err.message;
+        }
+      }
+    };
+
+    isTouched = (field) => {
+      const { touched } = this.state;
+      this.setState({
+        touched: {
+          ...touched,
+          [field]: true,
+        },
+      });
+    }
+
+    passwordType = (key) => {
+      if (key === 'Password' || key === 'Confirm Password') {
+        return 'password';
+      }
+      return '';
+    }
+
+    render() {
+      const {
+        open, onClose, onSubmit, classes,
+      } = this.props;
+      const { name, email, password } = this.state;
+      const ans = [];
+      Object.keys(constant).forEach((key) => {
+        ans.push(<Handler
+          label={key}
+          onChange={this.handleChange(key)}
+          onBlur={() => this.isTouched(key)}
+          helperText={this.getError(key)}
+          error={!!this.getError(key)}
+          icons={constant[key]}
+          type={this.passwordType(key)}
+        />);
+      });
+
+      return (
+        <>
+          <Dialog open={open} onClose={onClose} aria-labelledby="form-dialog-title">
+            <DialogTitle id="form-dialog-title">Add Trainee</DialogTitle>
+            <DialogContent>
+              <DialogContentText>
+            Enter your trainee details
+              </DialogContentText>
+              <div>
+                {ans[0]}
+              </div>
+              &nbsp;
+              <div>
+                {ans[1]}
+              </div>
+              &nbsp;
+              <div className={classes.passfield}>
+                <div className={classes.pass}>
+                  {ans[2]}
+                </div>
+                &nbsp;
+                &nbsp;
+                <div className={classes.pass}>
+                  {ans[3]}
+                </div>
+              </div>
+          &nbsp;
+              <div align="right">
+                <Button onClick={onClose} color="primary">CANCEL</Button>
+                <Button variant="contained" color="primary" disabled={this.hasErrors()} onClick={() => onSubmit()({ name, email, password })}>SUBMIT</Button>
+              </div>
+            </DialogContent>
+          </Dialog>
+        </>
+      );
+    }
+}
+export default withStyles(passwordStyle)(AddDialog);
+AddDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  classes: PropTypes.objectOf(PropTypes.string).isRequired,
+};

--- a/training/src/pages/Trainee/components/AddDialog/DialogSchema.jsx
+++ b/training/src/pages/Trainee/components/AddDialog/DialogSchema.jsx
@@ -1,0 +1,13 @@
+import * as yup from 'yup';
+
+const schema = yup.object().shape({
+  Name: yup.string().trim().required('Name is a required field').min(3),
+  Email: yup.string()
+    .trim().email().required('Email is a required field'),
+  Password: yup.string()
+    .required('Password is required')
+    .matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.{8,})/, 'Must contain 8 characters, at least one uppercase letter, one lowercase letter and one number'),
+  'Confirm Password': yup.string().required('Confirm Password is required').oneOf([yup.ref('Password'), null], 'Must match password'),
+});
+
+export default schema;

--- a/training/src/pages/Trainee/components/AddDialog/Handler.jsx
+++ b/training/src/pages/Trainee/components/AddDialog/Handler.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { TextField, InputAdornment } from '@material-ui/core';
+
+export default function Handler(props) {
+  const {
+    error, helperText, onChange, onBlur, label, type, icons,
+  } = props;
+  const Icon = icons;
+  return (
+    <>
+      <TextField
+        required
+        id="outlined-required"
+        label={label}
+        variant="outlined"
+        fullWidth
+        onChange={onChange}
+        onBlur={onBlur}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <Icon />
+            </InputAdornment>
+          ),
+        }}
+        helperText={helperText}
+        error={error}
+        type={type}
+      />
+    </>
+  );
+}
+Handler.propTypes = {
+  error: PropTypes.bool,
+  helperText: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  onBlur: PropTypes.func.isRequired,
+  label: PropTypes.string,
+  type: PropTypes.string,
+  icons: PropTypes.instanceOf(Object),
+};
+Handler.defaultProps = {
+  error: false,
+  helperText: '',
+  label: '',
+  type: false,
+  icons: {},
+};

--- a/training/src/pages/Trainee/components/AddDialog/index.js
+++ b/training/src/pages/Trainee/components/AddDialog/index.js
@@ -1,0 +1,1 @@
+export { default as AddDialog } from './AddDialog.jsx';

--- a/training/src/pages/Trainee/components/index.js
+++ b/training/src/pages/Trainee/components/index.js
@@ -1,0 +1,1 @@
+export { AddDialog } from './AddDialog';

--- a/training/src/pages/Trainee/index.js
+++ b/training/src/pages/Trainee/index.js
@@ -1,0 +1,1 @@
+export { default as Trainee } from './Trainee.jsx';

--- a/training/src/pages/index.js
+++ b/training/src/pages/index.js
@@ -1,3 +1,4 @@
 export { TextFieldDemo } from './TextFieldDemo';
 export { InputDemo } from './InputDemo';
 export { ChildrenDemo } from './ChildrenDemo';
+export { Trainee } from './Trainee';

--- a/training/src/pages/index.js
+++ b/training/src/pages/index.js
@@ -1,2 +1,3 @@
 export { TextFieldDemo } from './TextFieldDemo';
 export { InputDemo } from './InputDemo';
+export { ChildrenDemo } from './ChildrenDemo';

--- a/training/src/theme.js
+++ b/training/src/theme.js
@@ -1,0 +1,14 @@
+import { createMuiTheme } from '@material-ui/core';
+
+const theme = createMuiTheme({
+  typography: {
+    fontFamily: [
+      'Comic Sans MS',
+      'cursive',
+      'sans-serif',
+    ].join(','),
+    htmlfontSize: 100,
+  },
+});
+
+export default theme;


### PR DESCRIPTION
Day 9 - Material UI - Styling, Dialog, and Form Validation
1) Create a Trainee Component similar to other page component.
2) Inside Trainee Component create a folder named as components and create a new component AddDialog component
https://gyazo.com/3268e2b58ed78bd591db1ef3ce476c1a
3) AddDialog compoent will accept following props:
* open - boolean, will open the dialog if true.
* onClose - handler to close the dialog, passed from TraineeComponent
* onSubmit - handler to accept the dialog state for user: name, email, password
4) AddDialog will show information as show in the GIF
5) Add all the validations as shown in the GIF, similar to InputDemo component.
6) All the components used in the AddDialog must be from the Material UI.
7) TraineeComponent - Will hold the state of the Dialog, and update the state as per handler Request.
8) TraineeComponent - Will contain the button, and clicking on the button will open the dialog inside “AddDialog” component.