### PR TITLE
Feature/58720 (Querying the list)

### DIFF
--- a/training/package.json
+++ b/training/package.json
@@ -23,6 +23,7 @@
     "axios": "^0.21.1",
     "jsonwebtoken": "^8.5.1",
     "local-storage": "^2.0.0",
+    "lodash.flowright": "^3.5.0",
     "material-ui-password-field": "^2.1.2",
     "moment": "^2.29.1",
     "prop-types": "^15.7.2",

--- a/training/src/components/Table/TableComponent.jsx
+++ b/training/src/components/Table/TableComponent.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -31,7 +30,6 @@ function TableComponent(props) {
     classes, data, column, order, orderBy, onSort, onSelect, count, page, actions,
     rowsPerPage, onChangePage, onChangeRowsPerPage,
   } = props;
-  console.log(' data :', data);
 
   return (
     <TableContainer component={Paper}>

--- a/training/src/libs/apollo-client.js
+++ b/training/src/libs/apollo-client.js
@@ -12,7 +12,7 @@ const authLink = setContext((_, { headers }) => {
   return {
     headers: {
       ...headers,
-      authorization: token ? `Bearer ${token}` : '',
+      authorization: token ? `${token}` : '',
     },
   };
 });

--- a/training/src/pages/Trainee/Query.js
+++ b/training/src/pages/Trainee/Query.js
@@ -1,0 +1,17 @@
+import { gql } from 'apollo-boost';
+
+const GET_TRAINEE = gql`
+query GetTrainee($skip: Int, $limit:Int, $sort:String) {
+  getAllTrainees(payload: { skip: $skip, limit: $limit, sort: $sort}) {
+    status
+    message
+    TraineeCount
+    record{
+      name
+      email
+      createdAt
+    }
+    }
+  }`;
+
+export { GET_TRAINEE };

--- a/training/src/pages/Trainee/components/AddDialog/AddDialog.jsx
+++ b/training/src/pages/Trainee/components/AddDialog/AddDialog.jsx
@@ -57,11 +57,14 @@ class AddDialog extends React.Component {
       loading: true,
       hasError: true,
     });
+    // eslint-disable-next-line react/prop-types
+    const { refetch } = this.props;
     const response = await callApi(data, 'post', '/trainee');
     console.log('data :', data);
     this.setState({ loading: false });
     console.log('res :', response);
     if (response.status === 'OK') {
+      refetch();
       this.setState({
         hasError: false,
         message: 'This is a success message',
@@ -133,14 +136,11 @@ class AddDialog extends React.Component {
       const {
         open, onClose, classes,
       } = this.props;
-      // eslint-disable-next-line no-shadow
       const {
-        // eslint-disable-next-line no-shadow
         name, email, password, loading,
       } = this.state;
       const ans = [];
       Object.keys(constant).forEach((key) => {
-        // console.log('key:', key);
         ans.push(<Handler
           label={key}
           onChange={this.handleChange(key)}


### PR DESCRIPTION
AC
Replace the API for fetching trainee list with Graph API call with the help of the Query component.

Prerequisites

Install the package apollo-link-context.
Configuring the apollo client to send request headers.
In your lib/graphql-client file import setContext from the above package.
Call the setContext method and pass a callback which will be responsible for appending the headers for all requests.
Pass the above-created context as a link argument to the Apollo Client instance and call the available context's concat method with the HTTP link variable as an argument.
Steps

Add Query getTrainee query in query.js file in pages/trainee module.
Use the graphql HOC from @apollo/react-hoc package for doing the query.
Wrap trainee list component with graphql HOC and pass the query as well as required variables as parameters.
Update the logic for generating listing accordingly.
Replace the logic for pagination with Refetch API.

My Output:
![day8](https://user-images.githubusercontent.com/72734557/106143952-81c51700-6199-11eb-9a32-d9f2448b6486.png)
![day8(1)](https://user-images.githubusercontent.com/72734557/106143967-85f13480-6199-11eb-8703-063dce304c37.png)
